### PR TITLE
define name attr, required by Berkshelf/Ridley.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,6 @@
 maintainer       "Max Prokopiev"
 maintainer_email "me@maxprokopiev.com"
+name             "leiningen"
 license          "Apache 2.0"
 description      "Installs/Configures stable leiningen"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))


### PR DESCRIPTION
Without the 'name' attribute in metadata.rb, I get this problem running Berkshelf:

```
   Resolving cookbook dependencies with Berkshelf 3.2.4...
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #converge action: [The following error occurred while reading the cookbook `leiningen':
Ridley::Errors::MissingNameAttribute: The metadata at '/var/folders/lt/lytf10857vg08qy8x_cznyxcg_gv9r/T/d20150901-2134-1o0ebtm' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.]
>>>>>> ---------------------- 
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

With the change in this pull request, the problem goes away.
