### PR TITLE
Add name field to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "leiningen"      
 maintainer       "Max Prokopiev"
 maintainer_email "me@maxprokopiev.com"
 license          "Apache 2.0"


### PR DESCRIPTION
According this https://docs.chef.io/config_rb_metadata.html name is required field. Also Amazon OpsWorks wont work without that field.
